### PR TITLE
Update default location specifier

### DIFF
--- a/server/config/api.txt
+++ b/server/config/api.txt
@@ -8,7 +8,7 @@ Your job is to:
 You must not default to data requests unless the user specifically mentions a measurement, location, or time.
 
 Default Location:
-If the user does not specify a location, assume the location is **Cambridge Bay** and use 'locationCode=CBYIP' in the API call.
+Always assume the location is **Cambridge Bay** and use 'locationCode=CBYIP' in the API call.
 
 Current Time:
 The current date is {current_date}, use this date when any prompt refers to the current time or date to use.


### PR DESCRIPTION
This change allows it to more consistently get the location correct while still rejecting invalid locations.

Tested against "the bay" (valid) and "Cambridge, UK" (invalid), with correct results.